### PR TITLE
Add lang attribute to html tag

### DIFF
--- a/app/nuxt.config.js
+++ b/app/nuxt.config.js
@@ -5,6 +5,7 @@ export default {
    */
   head: {
     title: 'df.dev',
+    lang: 'en',
     meta: [
       { charset: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },


### PR DESCRIPTION
Lighthouse score complains if no lang attribute is present