### PR TITLE
Fix image sizing for blog posts

### DIFF
--- a/app/pages/blog/_post.vue
+++ b/app/pages/blog/_post.vue
@@ -41,6 +41,11 @@
   @apply underline;
   @apply text-indigo-700;
 }
+
+.post-content >>> img {
+  max-width: 100%;
+  height: auto;
+}
 </style>
 
 <script>


### PR DESCRIPTION
before:
<img width="1664" alt="Screen Shot 2022-07-25 at 8 45 50 PM" src="https://user-images.githubusercontent.com/10299228/180918619-08251982-8ef8-4cfb-82fd-272cc5bb486c.png">

after:
<img width="820" alt="Screen Shot 2022-07-25 at 8 45 37 PM" src="https://user-images.githubusercontent.com/10299228/180918626-7b7ee432-f64c-4fd2-8fd2-e8ab11d675d0.png">

